### PR TITLE
Allow getOccurrences to be used on getTVKQuery results

### DIFF
--- a/R/getOccurrences.R
+++ b/R/getOccurrences.R
@@ -63,7 +63,7 @@ getOccurrences <- function(tvks=NULL, datasets=NULL, startYear=NULL,
     if(!is.null(tvks) & !is.null(group)) stop('group and tvks cannot be used at the same time')
     if(is.null(tvks) & is.null(group) & is.null(gridRef) & is.null(polygon) & is.null(point)) stop('One of group, tvks or gridRef must be given')
     if(is.data.frame(tvks)){
-      if(!("ptaxonVersionKey" %in% names(tvks))) stop("pTaxonVersionKey column missing from data.frame tvks")
+      if(!("ptaxonVersionKey" %in% names(tvks))) stop("ptaxonVersionKey column missing from data.frame tvks")
     
       tvks <- unique(as.character(tvks$ptaxonVersionKey))
     } 

--- a/R/getOccurrences.R
+++ b/R/getOccurrences.R
@@ -62,6 +62,9 @@ getOccurrences <- function(tvks=NULL, datasets=NULL, startYear=NULL,
     
     if(!is.null(tvks) & !is.null(group)) stop('group and tvks cannot be used at the same time')
     if(is.null(tvks) & is.null(group) & is.null(gridRef) & is.null(polygon) & is.null(point)) stop('One of group, tvks or gridRef must be given')
+    if(is.data.frame(tvks) && "pTaxonVersionKey" %in% names(tvks)){
+      tvks <- as.character(tvks$pTaxonVersionKey)
+    }
     
     # If we are searching by group get the group tvks
     if(!is.null(group)) tvks <- getGroupSpeciesTVKs(group)

--- a/R/getOccurrences.R
+++ b/R/getOccurrences.R
@@ -62,9 +62,11 @@ getOccurrences <- function(tvks=NULL, datasets=NULL, startYear=NULL,
     
     if(!is.null(tvks) & !is.null(group)) stop('group and tvks cannot be used at the same time')
     if(is.null(tvks) & is.null(group) & is.null(gridRef) & is.null(polygon) & is.null(point)) stop('One of group, tvks or gridRef must be given')
-    if(is.data.frame(tvks) && "pTaxonVersionKey" %in% names(tvks)){
-      tvks <- as.character(tvks$pTaxonVersionKey)
-    }
+    if(is.data.frame(tvks)){
+      if(!("ptaxonVersionKey" %in% names(tvks))) stop("pTaxonVersionKey column missing from data.frame tvks")
+    
+      tvks <- unique(as.character(tvks$ptaxonVersionKey))
+    } 
     
     # If we are searching by group get the group tvks
     if(!is.null(group)) tvks <- getGroupSpeciesTVKs(group)

--- a/tests/testthat/testgetOccurrences.R
+++ b/tests/testthat/testgetOccurrences.R
@@ -51,6 +51,19 @@ test_that("Check multi TVK search", {
     
 })
 
+test_that("query uses pTaxonVersionKey if tvks is a data frame (from getTVKQuery)",{
+  if(!file.exists('~/rnbn_test.rdata')) skip('login details not found')
+  # login
+  load('~/rnbn_test.rdata')
+  nbnLogin(username = UN_PWD$username, password = UN_PWD$password)
+  
+  dt <- getOccurrences(tvks="NBNSYS0000002987", datasets="GA000373", 
+                       startYear="1990", endYear="1991", acceptTandC=TRUE, silent = TRUE)
+  dt2 <- getOccurrences(tvks=data.frame(entityType="taxon", searchMatchTitle="Silene uniflora", pTaxonVersionKey="NBNSYS0000002987"), datasets="GA000373", 
+                       startYear="1990", endYear="1991", acceptTandC=TRUE, silent = TRUE)
+  expect_that(dt, equals(dt2))
+})
+
 
 test_that("Check group search", {
     if(!file.exists('~/rnbn_test.rdata')) skip('login details not found')

--- a/tests/testthat/testgetOccurrences.R
+++ b/tests/testthat/testgetOccurrences.R
@@ -51,7 +51,7 @@ test_that("Check multi TVK search", {
     
 })
 
-test_that("query uses pTaxonVersionKey if tvks is a data frame (from getTVKQuery)",{
+test_that("query uses ptaxonVersionKey if tvks is a data frame (from getTVKQuery)",{
   if(!file.exists('~/rnbn_test.rdata')) skip('login details not found')
   # login
   load('~/rnbn_test.rdata')
@@ -59,9 +59,13 @@ test_that("query uses pTaxonVersionKey if tvks is a data frame (from getTVKQuery
   
   dt <- getOccurrences(tvks="NBNSYS0000002987", datasets="GA000373", 
                        startYear="1990", endYear="1991", acceptTandC=TRUE, silent = TRUE)
-  dt2 <- getOccurrences(tvks=data.frame(entityType="taxon", searchMatchTitle="Silene uniflora", pTaxonVersionKey="NBNSYS0000002987"), datasets="GA000373", 
+  dt2 <- getOccurrences(tvks=data.frame(entityType="taxon", searchMatchTitle="Silene uniflora", ptaxonVersionKey="NBNSYS0000002987"), datasets="GA000373", 
                        startYear="1990", endYear="1991", acceptTandC=TRUE, silent = TRUE)
   expect_that(dt, equals(dt2))
+})
+
+test_that("data frames missing pTaxonVersionKey column are rejected",{
+  expect_error(getOccurrences(data.frame(a=1:10, b=1:10)), "column missing")
 })
 
 


### PR DESCRIPTION
When using `getOccurrences` with `getTVKQuery` results it easy to accidentally get unexpected results if the data frame from the latter is used as the query parameter.

This patch extracts the `pTaxonVersionKey` of data frames passed to `getOccurrences` if there is one and uses it as the list of TVKs.